### PR TITLE
use m.test

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
     "m.static": "bin/m.static"
   },
   "devDependencies": {
-    "mocha": "^2.5.3"
+    "m.test": "0.0.57"
   },
   "scripts": {
-    "test": "mocha",
+    "test": "m.test",
     "preversion": "npm test"
   },
   "repository": {
@@ -29,5 +29,6 @@
   "bugs": {
     "url": "https://github.com/ivoputzer/m.static/issues"
   },
-  "homepage": "https://github.com/ivoputzer/m.static#readme"
+  "homepage": "https://github.com/ivoputzer/m.static#readme",
+  "dependencies": {}
 }

--- a/test/index.js
+++ b/test/index.js
@@ -2,36 +2,36 @@ const {static} = require('..')
 const {get} = require('http')
 const {equal, throws, notEqual} = require('assert')
 const {join} = require('path')
+const {test}= require('m.test')
 
-describe('m.icro', function () {
-  it('uses standard module loading', () => {
+test('m.icro', function () {
+  test('uses standard module loading', () => {
     let module = require('..')
     notEqual(module.static, undefined)
   })
 })
 
-describe('m.static', function(){
-  it('throws an error when no options are given', () => {
+test('m.static', function(){
+  test('throws an error when no options are given', () => {
     throws(static, Error)
   })
 
   const server = static({cwd: __dirname})
 
-  before((done) => server.listen(9999, done))
-  after((done) => server.close(done))
-
-  it('exposes a `listen` fn as of net.Server', () => {
+  test('exposes a `listen` fn as of net.Server', () => {
     equal(typeof server.listen, 'function')
   })
 
-  it('exposes a `close` fn as of net.Server', () => {
+  test('exposes a `close` fn as of net.Server', () => {
     equal(typeof server.close, 'function')
   })
 
-  it('loads static files within `cwd`', (done) => {
-    get('http://localhost:9999/index.html', (res) => {
-      equal(200, res.statusCode)
-      done()
+  test('loads static files within `cwd`', (done) => {
+    server.listen(9999, () => {
+      get('http://localhost:9999/index.html', (res) => {
+        equal(200, res.statusCode)
+        server.close(done)
+      })
     })
   })
 })


### PR DESCRIPTION
Related issue: https://github.com/ivoputzer/m.static/issues/1

Introduces m.test

I had to make small changes to tests to make the compatible with m.test.

The test output **before** was:

```
~/D/p/m.static (master) npm t

> m.static@1.1.0 test /Users/christian/Documents/projects/m.static
> mocha



  m.icro
    ✓ uses standard module loading

  m.static
    ✓ throws an error when no options are given
    ✓ exposes a `listen` fn as of net.Server
    ✓ exposes a `close` fn as of net.Server
    ✓ loads static files within `cwd`


  5 passing (23ms)
```


The test output **after** was:
```
~/D/p/m.static (master ⚡) t

> m.static@1.1.0 test /Users/christian/Documents/projects/m.static
> m.test

m.icro
  ✔ uses standard module loading (0ms)
m.static
  ✔ throws an error when no options are given (0ms)
  ✔ exposes a `listen` fn as of net.Server (0ms)
  ✔ exposes a `close` fn as of net.Server (0ms)
  ✔ loads static files within `cwd` (17ms)
```