### PR TITLE
rename to createFileServer

### DIFF
--- a/bin/m.static
+++ b/bin/m.static
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
-const {static} = require('..')
+const {createFileServer} = require('..')
 
 const port = process.argv[2] || 8088
 const cwd = process.argv[3] || process.cwd()
 
-static({cwd}).listen(port)
+createFileServer({cwd}).listen(port)

--- a/index.js
+++ b/index.js
@@ -1,16 +1,14 @@
-const encoding = 'utf8'
-
 const {createReadStream} = require('fs')
 const {createServer} = require('http')
 const {join, normalize} = require('path')
 const {stringify} = JSON
 
-function static(options) {
+function createFileServer (options) {
   if (!options) throw new Error('options are mandatory')
   return createServer(requestHandlerFor(options))
 }
 
-function requestHandlerFor(options) {
+function requestHandlerFor (options) {
   return (req, res) => {
     const filename = join(options.cwd, normalize(req.url))
     createReadStream(filename)
@@ -19,10 +17,10 @@ function requestHandlerFor(options) {
   }
 }
 
-function errorHandlerFor(req, res){
+function errorHandlerFor (req, res) {
   return (err) => {
     res.end(stringify(err))
   }
 }
 
-module.exports = {static}
+module.exports = {createFileServer}

--- a/test/index.js
+++ b/test/index.js
@@ -1,22 +1,21 @@
-const {static} = require('..')
+const {createFileServer} = require('..')
 const {get} = require('http')
 const {equal, throws, notEqual} = require('assert')
-const {join} = require('path')
-const {test}= require('m.test')
+const {test} = require('m.test')
 
 test('m.icro', function () {
   test('uses standard module loading', () => {
     let module = require('..')
-    notEqual(module.static, undefined)
+    notEqual(module.createFileServer, undefined)
   })
 })
 
-test('m.static', function(){
+test('m.createFileServer', function () {
   test('throws an error when no options are given', () => {
-    throws(static, Error)
+    throws(createFileServer, Error)
   })
 
-  const server = static({cwd: __dirname})
+  const server = createFileServer({cwd: __dirname})
 
   test('exposes a `listen` fn as of net.Server', () => {
     equal(typeof server.listen, 'function')
@@ -26,7 +25,7 @@ test('m.static', function(){
     equal(typeof server.close, 'function')
   })
 
-  test('loads static files within `cwd`', (done) => {
+  test('loads createFileServer files within `cwd`', (done) => {
     server.listen(9999, () => {
       get('http://localhost:9999/index.html', (res) => {
         equal(200, res.statusCode)


### PR DESCRIPTION
There was an issue with the exported function by this library, called `static`.
It is a reserved keyword in the language, so it cannot be used.

This PR renames this exported function to `createFileServer` :)